### PR TITLE
Fix paper provider portal

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/App.js
+++ b/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider as PaperProvider } from 'react-native-paper';
 import AppContainer from './navigation/AppNavigator';
 import { theme } from './constants/Theme';
-import FontAwesome5 from 'react-native-vector-icons/FontAwesome5';
+import { Icon } from './components/Icon';
 
 // TODO: Check out how to pass a theme to PaperProvider:
 // https://github.com/callstack/react-native-paper-login-template/blob/master/App.tsx
@@ -13,7 +13,7 @@ export default class App extends React.Component {
     return (
       <PaperProvider
         settings={{
-          icon: props => <FontAwesome5 name={props.icon} {...props} />,
+          icon: props => <Icon name={props.icon} {...props} />,
         }}
         theme={theme}
       >

--- a/components/FindWaypointsButton.js
+++ b/components/FindWaypointsButton.js
@@ -1,6 +1,7 @@
-import * as React from 'react';
-import { StyleSheet } from 'react-native';
-import { FAB, Portal, Provider } from 'react-native-paper';
+import React from 'react';
+import { FAB } from 'react-native-paper';
+import FontAwesome5 from 'react-native-vector-icons/FontAwesome5';
+import { Icon } from './Icon';
 
 export default class FindWaypointsButton extends React.Component {
   state = {
@@ -10,9 +11,8 @@ export default class FindWaypointsButton extends React.Component {
   render() {
     return (
       <FAB.Group
-        // style={styles.fab}
         open={this.state.open}
-        icon="search"
+        icon={this.state.open ? 'times' : 'search'}
         actions={[
           {
             icon: 'campground',
@@ -31,25 +31,7 @@ export default class FindWaypointsButton extends React.Component {
           },
         ]}
         onStateChange={({ open }) => this.setState({ open })}
-        onPress={() => {
-          if (this.state.open) {
-            // do something if the speed dial is open
-          }
-        }}
       />
     );
   }
 }
-
-// const FindWaypointsButton = props => (
-//   <FAB {...props} style={styles.fab} small icon="search" />
-// );
-
-// const styles = StyleSheet.create({
-//   fab: {
-//     position: "absolute",
-//     margin: 16,
-//     right: 10,
-//     bottom: 30
-//   }
-// });

--- a/components/FindWaypointsButton.js
+++ b/components/FindWaypointsButton.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import { FAB } from 'react-native-paper';
-import FontAwesome5 from 'react-native-vector-icons/FontAwesome5';
-import { Icon } from './Icon';
 
 export default class FindWaypointsButton extends React.Component {
   state = {

--- a/components/Icon.js
+++ b/components/Icon.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import FontAwesome5 from 'react-native-vector-icons/FontAwesome5';
+
+export const Icon = props => {
+  const { size, color, name } = props;
+  return (
+    <View style={styles.iconAlignment}>
+      <FontAwesome5 name={name} size={size} color={color} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  iconAlignment: {
+    alignItems: 'center',
+  },
+});

--- a/components/Map.js
+++ b/components/Map.js
@@ -6,29 +6,6 @@ import { StyleSheet, View, Dimensions } from 'react-native';
 
 MapboxGL.setAccessToken(MAPBOX_API_KEY);
 
-const styles = StyleSheet.create({
-  page: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F5FCFF',
-  },
-  container: {
-    width: Dimensions.get('window').width,
-    height: Dimensions.get('window').height,
-    backgroundColor: 'tomato',
-  },
-  map: {
-    flex: 1,
-  },
-});
-
-const layerStyles = {
-  pctLine: {
-    lineColor: 'rgb(204, 0, 0)',
-  },
-};
-
 export class Map extends React.Component {
   componentDidMount() {
     MapboxGL.setTelemetryEnabled(false);
@@ -36,28 +13,43 @@ export class Map extends React.Component {
 
   render() {
     return (
-      <View style={styles.page}>
-        <View style={styles.container}>
-          <MapboxGL.MapView
-            ref={ref => (this.map = ref)}
-            style={styles.map}
-            styleURL="mapbox://styles/mapbox/streets-v11"
-          >
-            <MapboxGL.Camera
-              zoomLevel={10}
-              centerCoordinate={[-116.5085524, 32.6524889]}
-            />
+      <View style={styles.container}>
+        <MapboxGL.MapView
+          ref={ref => (this.map = ref)}
+          style={styles.map}
+          styleURL="mapbox://styles/mapbox/streets-v11"
+        >
+          <MapboxGL.Camera
+            zoomLevel={10}
+            centerCoordinate={[-116.5085524, 32.6524889]}
+          />
 
-            <MapboxGL.ShapeSource
-              id="pctSource"
-              shape={MapData}
-              onPress={() => console.log('Nemo touched the line!')}
-            >
-              <MapboxGL.LineLayer id="pctLine" style={layerStyles.pctLine} />
-            </MapboxGL.ShapeSource>
-          </MapboxGL.MapView>
-        </View>
+          <MapboxGL.ShapeSource
+            id="pctSource"
+            shape={MapData}
+            onPress={() => console.log('Nemo touched the line!')}
+          >
+            <MapboxGL.LineLayer id="pctLine" style={layerStyles.pctLine} />
+          </MapboxGL.ShapeSource>
+        </MapboxGL.MapView>
       </View>
     );
   }
 }
+
+const layerStyles = {
+  pctLine: {
+    lineColor: 'rgb(204, 0, 0)',
+  },
+};
+
+const styles = StyleSheet.create({
+  container: {
+    width: Dimensions.get('window').width,
+    height: Dimensions.get('window').height,
+    backgroundColor: 'transparent',
+  },
+  map: {
+    flex: 1,
+  },
+});

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
  * @format
  */
 
-import {AppRegistry} from 'react-native';
+import { AppRegistry } from 'react-native';
 import App from './App';
-import {name as appName} from './app.json';
+import { name as appName } from './app.json';
 
 AppRegistry.registerComponent(appName, () => App);

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,14 +1,11 @@
 import React from 'react';
-import { View, StyleSheet, Dimensions } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { Map } from '../components/Map';
 import DrawerButton from '../components/DrawerButton';
 import AddContentButton from '../components/AddContentButton';
 import FindWaypointsButton from '../components/FindWaypointsButton';
 import { FAB, Portal, Provider } from 'react-native-paper';
-import ExpandingButton from '../components/ExpandingButton';
 
-// TODO: Debug why adding <Portal> stops the FontAwesome icons from working
-// I think you need to use <Portal> to get the FAB group to render at the right place on top of other objects
 export default class HomeScreen extends React.Component {
   constructor(props) {
     super(props);
@@ -25,29 +22,47 @@ export default class HomeScreen extends React.Component {
   render() {
     return (
       <View style={styles.container}>
-        <Map style={styles.map} />
-        <DrawerButton onPress={() => this.props.navigation.toggleDrawer()} />
-        <AddContentButton onPress={() => console.log('add content')} />
+        <Map />
+        <Provider>
+          <Portal>
+            {/* Layers button */}
+            <FAB style={styles.layersFAB} icon="layer-group" />
+            {/* Center on location button */}
+            <FAB style={styles.locatorFAB} icon="location-arrow" />
+          </Portal>
+        </Provider>
+        <Provider>
+          <Portal>
+            <DrawerButton
+              onPress={() => this.props.navigation.toggleDrawer()}
+            />
+            <AddContentButton onPress={() => console.log('add content')} />
 
-        <FAB
-          small
-          style={styles.elevationFAB}
-          icon="mountain"
-          label="Elevation"
-          onPress={() => this.toggleElevation()}
-        />
+            <FAB
+              small
+              style={styles.elevationFAB}
+              icon="mountain"
+              label="Elevation"
+              onPress={() => this.toggleElevation()}
+            />
 
-        <FAB style={styles.layersFAB} icon="layer-group" />
-
-        <FAB style={styles.locatorFAB} icon="location-arrow" />
-
-        <FindWaypointsButton onPress={() => console.log('Find waypoints')} />
+            <FindWaypointsButton
+              onPress={() => console.log('Find waypoints')}
+            />
+          </Portal>
+        </Provider>
       </View>
     );
   }
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+  },
   layersFAB: {
     position: 'absolute',
     margin: 16,
@@ -65,18 +80,5 @@ const styles = StyleSheet.create({
     margin: 16,
     left: 10,
     bottom: 40,
-  },
-  map: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: Dimensions.get('window').width,
-    height: Dimensions.get('window').height,
-  },
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
   },
 });

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -6,6 +6,11 @@ import AddContentButton from '../components/AddContentButton';
 import FindWaypointsButton from '../components/FindWaypointsButton';
 import { FAB, Portal, Provider } from 'react-native-paper';
 
+// Note: I currently have the FAB.group component (i.e. FindWaypointsButton) in
+// a separate <Provider><Portal> tree than the layers and locator FABs. This is
+// required so that when FindWaypointsButton is clicked, the options that then
+// show up appear _above_ the layers and locator FABs, and not beneath them.
+
 export default class HomeScreen extends React.Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
This fixes the appearance of the floating action buttons on the Home screen, and `FindWaypointsButton` in particular. Every FAB must be wrapped in `<Provider><Portal>` so that it appears on top of the base component (the `Map`). Also note that it's important to have the `FAB.group` component (i.e. `FindWaypointsButton`) in
a separate `<Provider><Portal>` tree than the layers and locator FABs. This is
required so that when `FindWaypointsButton` is clicked, the options that then
show up appear _above_ the layers and locator FABs, and not beneath them.

I first figured this out in this [snack](https://snack.expo.io/@kylebarron/fab-maps-portal), and then ported it to work with the native map. One of the issues was that I had `MapboxGl.Mapview` in an extra view component that made it share the bottom part of the screen.
